### PR TITLE
Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 keywords = ["cd", "cd-rom", "cue_sheet"]
 categories = ["api-bindings", "parser-implementations"]
 version = "1.0.0"
+edition = "2018"
 authors = ["Misty De Meo <mistydemeo@gmail.com>"]
 license = "GPL-2.0-or-later"
 

--- a/cue-sys/Cargo.toml
+++ b/cue-sys/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/mistydemeo/libcue.rs"
 keywords = ["cd", "cd-rom", "cue_sheet"]
 categories = ["external-ffi-bindings", "parser-implementations"]
 version = "1.0.0"
+edition = "2018"
 authors = ["Misty De Meo <mistydemeo@gmail.com>"]
 license = "GPL-2.0-or-later"
 

--- a/cue-sys/src/lib.rs
+++ b/cue-sys/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 pub enum CdPointer {}
 pub enum CdtextPointer {}
 pub enum TrackPointer {}

--- a/src/cd/mod.rs
+++ b/src/cd/mod.rs
@@ -1,12 +1,12 @@
 use std::ffi::{CString, NulError};
 use std::fs::File;
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 use std::path::PathBuf;
 
-use libc;
 use cue_sys as libcue;
 pub use cue_sys::DiscMode;
+use libc;
 
 use crate::cd_text::CDText;
 use crate::rem::REM;
@@ -74,9 +74,7 @@ impl CD {
         unsafe {
             cd = libcue::cue_parse_string(c_string.as_ptr());
         }
-        let cd_type = CD {
-            cd: cd,
-        };
+        let cd_type = CD { cd: cd };
         return Ok(cd_type);
     }
 

--- a/src/cd/mod.rs
+++ b/src/cd/mod.rs
@@ -8,9 +8,9 @@ use libc;
 use cue_sys as libcue;
 pub use cue_sys::DiscMode;
 
-use cd_text::CDText;
-use rem::REM;
-use track::Track;
+use crate::cd_text::CDText;
+use crate::rem::REM;
+use crate::track::Track;
 
 /// The CD struct represents the entirety of a CD, which is the core unit of
 /// a CUE sheet. This struct contains the parsing methods used as the primary

--- a/src/cd_text/mod.rs
+++ b/src/cd_text/mod.rs
@@ -21,9 +21,7 @@ pub struct CDText {
 
 impl CDText {
     pub fn from(pointer: *mut libcue::CdtextPointer) -> CDText {
-        return CDText {
-            cdtext: pointer,
-        };
+        return CDText { cdtext: pointer };
     }
 
     /// Returns the CD-TEXT data represented by this struct as a string, if present.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@
 //! Its documentation is available
 //! [in its own git repository](https://github.com/lipnitsk/libcue/blob/master/libcue.h).
 
-extern crate libc;
-extern crate cue_sys;
-
 /// The `CD` struct represents a disc, and is the entry point to parsing a CUE sheet.
 pub mod cd;
 /// The `CDText` struct represents [CD-TEXT](https://en.wikipedia.org/wiki/CD-Text) data

--- a/src/rem/mod.rs
+++ b/src/rem/mod.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 
-use libc;
 use cue_sys as libcue;
+use libc;
 
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -25,9 +25,7 @@ pub struct REM {
 
 impl REM {
     pub fn from(pointer: *mut libcue::RemPointer) -> REM {
-        return REM {
-            rem: pointer,
-        };
+        return REM { rem: pointer };
     }
 
     /// Returns the comment represented by this struct as a string, if present.

--- a/src/track/mod.rs
+++ b/src/track/mod.rs
@@ -4,8 +4,8 @@ use libc;
 use cue_sys as libcue;
 pub use cue_sys::{TrackMode, TrackSubMode, TrackFlag};
 
-use cd_text::CDText;
-use rem::REM;
+use crate::cd_text::CDText;
+use crate::rem::REM;
 
 /// The Track struct represents a single track within a CD.
 /// A track can be one of several types, represented by the

--- a/src/track/mod.rs
+++ b/src/track/mod.rs
@@ -1,8 +1,8 @@
 use std::ffi::CString;
 
-use libc;
 use cue_sys as libcue;
-pub use cue_sys::{TrackMode, TrackSubMode, TrackFlag};
+pub use cue_sys::{TrackFlag, TrackMode, TrackSubMode};
+use libc;
 
 use crate::cd_text::CDText;
 use crate::rem::REM;
@@ -44,9 +44,7 @@ pub struct Track {
 
 impl Track {
     pub fn from(pointer: *mut libcue::TrackPointer) -> Track {
-        return Track {
-            track: pointer,
-        };
+        return Track { track: pointer };
     }
 
     /// Returns the filename of the file containing this track.


### PR DESCRIPTION
Upgrades to Rust 2018, and runs `rustfmt`.