### PR TITLE
Fix double free

### DIFF
--- a/src/cd/mod.rs
+++ b/src/cd/mod.rs
@@ -1,4 +1,4 @@
-use std::ffi::{CString, NulError};
+use std::ffi::{CStr, CString, NulError};
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;
@@ -104,15 +104,15 @@ impl CD {
     /// # Safety
     /// This may segfault if there is no CD-TEXT sidecar.
     pub fn get_cdtextfile(&self) -> Option<String> {
-        let c_string;
+        let c_str;
         unsafe {
             let raw_string = libcue::cd_get_cdtextfile(self.cd);
             if raw_string.is_null() {
                 return None;
             }
-            c_string = CString::from_raw(raw_string);
+            c_str = CStr::from_ptr(raw_string);
         }
-        return Some(c_string.to_string_lossy().into_owned());
+        return Some(c_str.to_string_lossy().into_owned());
     }
 
     /// Returns the total number of tracks in this CD.

--- a/src/cd_text/mod.rs
+++ b/src/cd_text/mod.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 
 use cue_sys as libcue;
 pub use cue_sys::PTI;
@@ -26,14 +26,14 @@ impl CDText {
 
     /// Returns the CD-TEXT data represented by this struct as a string, if present.
     pub fn read(&self, pack_type: PTI) -> Option<String> {
-        let c_string;
+        let c_str;
         unsafe {
             let raw_string = libcue::cdtext_get(pack_type, self.cdtext);
             if raw_string.is_null() {
                 return None;
             }
-            c_string = CString::from_raw(raw_string);
+            c_str = CStr::from_ptr(raw_string);
         }
-        return Some(c_string.to_string_lossy().into_owned());
+        return Some(c_str.to_string_lossy().into_owned());
     }
 }

--- a/src/rem/mod.rs
+++ b/src/rem/mod.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 
 use cue_sys as libcue;
 use libc;
@@ -30,14 +30,14 @@ impl REM {
 
     /// Returns the comment represented by this struct as a string, if present.
     pub fn read(&self, index: usize) -> Option<String> {
-        let c_string;
+        let c_str;
         unsafe {
             let raw_string = libcue::rem_get(index as libc::c_uint, self.rem);
             if raw_string.is_null() {
                 return None;
             }
-            c_string = CString::from_raw(raw_string);
+            c_str = CStr::from_ptr(raw_string);
         }
-        return Some(c_string.to_string_lossy().into_owned());
+        return Some(c_str.to_string_lossy().into_owned());
     }
 }

--- a/src/track/mod.rs
+++ b/src/track/mod.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 
 use cue_sys as libcue;
 pub use cue_sys::{TrackFlag, TrackMode, TrackSubMode};
@@ -51,12 +51,12 @@ impl Track {
     /// The track might be stored standalone in its own file, or
     /// as part of a large file containing the contents of the entire disc.
     pub fn get_filename(&self) -> String {
-        let c_string;
+        let c_str;
         unsafe {
             let raw_string = libcue::track_get_filename(self.track);
-            c_string = CString::from_raw(raw_string);
+            c_str = CStr::from_ptr(raw_string);
         }
-        return c_string.to_string_lossy().into_owned();
+        return c_str.to_string_lossy().into_owned();
     }
 
     /// Returns the start address of this track in sectors.
@@ -130,15 +130,15 @@ impl Track {
     /// While some CDs use ISRCs, they are not common and many
     /// CUE sheets leave them out even if the CD had them.
     pub fn get_isrc(&self) -> Option<String> {
-        let c_string;
+        let c_str;
         unsafe {
             let raw_string = libcue::track_get_isrc(self.track);
             if raw_string.is_null() {
                 return None;
             }
-            c_string = CString::from_raw(raw_string);
+            c_str = CStr::from_ptr(raw_string);
         }
-        return Some(c_string.to_string_lossy().into_owned());
+        return Some(c_str.to_string_lossy().into_owned());
     }
 
     /// Returns the track number.


### PR DESCRIPTION
When I used this crate, I found occurring double free. I fixed double free.

Before
```
   Doc-tests cue

running 1 test
test src/cd/mod.rs - cd::CD (line 26) ... FAILED

failures:

---- src/cd/mod.rs - cd::CD (line 26) stdout ----
Test executable failed (terminated by signal).

stdout:
Number of tracks: 3
Mode: CD-DA

Track 1
Filename: example.img
Start: 0
Length: 264111
Pregap: 0
Postgap: 0

Track 2
Filename: example.img
Start: 264111
Length: 10847
Pregap: 150
Postgap: 0

Track 3
Filename: example.img
Start: 274958
Length: 0
Pregap: 0
Postgap: 0


stderr:
free(): double free detected in tcache 2



failures:
    src/cd/mod.rs - cd::CD (line 26)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.47s

error: test failed, to rerun pass '--doc'
```

After
```
   Doc-tests cue

running 1 test
test src/cd/mod.rs - cd::CD (line 26) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
```