### PR TITLE
cmake: fix build with 4.x

### DIFF
--- a/cue-sys/build.rs
+++ b/cue-sys/build.rs
@@ -5,6 +5,7 @@ fn main() {
 
     let dst = Config::new("vendor/libcue")
         .define("BUILD_SHARED_LIBS", "OFF")
+        .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
         .build();
     println!(
         "cargo:rustc-link-search=native={}",


### PR DESCRIPTION
We need to set this environment variable for cmake 4.x to accept the CMakeLists.txt in the vendored project.